### PR TITLE
Fix for double-defining CRON_FLUSH_BUFFERS

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -24,7 +24,6 @@
 define('CRON_CI_INDEX', 'index.php');   // Your CodeIgniter main index.php file
 //define('CRON_CI_INDEX', '/var/www/vhosts/myaccount/index.php');   // Your CodeIgniter main index.php file
 define('CRON', TRUE);   // Test for this in your controllers if you only want them accessible via cron
-define('CRON_FLUSH_BUFFERS', FALSE);
 
 // Parse the command line
 $script = array_shift($argv);
@@ -65,6 +64,11 @@ foreach($argv as $arg)
         default:
             die($usage);
     }
+}
+
+if (!defined('CRON_FLUSH_BUFFERS'))
+{
+    define('CRON_FLUSH_BUFFERS', FALSE);
 }
 
 $_SERVER['argv'][1] = $uri;


### PR DESCRIPTION
CRON_FLUSH_BUFFERS was defined twice if cron.php was called with -S or --show-output, causing "Constant already defined" notice. Fixed.
